### PR TITLE
Add Aptos ERC20 token example

### DIFF
--- a/Move.toml
+++ b/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "AptosERC20"
+version = "0.0.1"
+authors = ["example"]
+
+[addresses]
+token = "0x0"
+
+[dependencies]
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework", rev = "main" }

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,35 @@
-111
+# Aptos ERC20 Example
+
+This project demonstrates an ERC20-like fungible token implemented in Move for the Aptos testnet. It includes the Move module and helper scripts for deployment and basic interaction.
+
+## Layout
+- `Move.toml` and `sources/` contain the Move package defining the token.
+- `scripts/deploy.sh` publishes the package to the testnet.
+- `scripts/test.sh` registers an account, mints tokens, and prints the balance.
+- `scripts/test.py` does the same using the Aptos Python SDK.
+
+## Deployment
+1. Install the [Aptos CLI](https://aptos.dev/cli-tools/aptos-cli-tool/install-aptos-cli/).
+2. Create or configure an Aptos profile that points to testnet and holds the deployer's keys.
+3. Publish the module, replacing `<deployer-address>` with your account address:
+
+```bash
+./scripts/deploy.sh <deployer-address> [profile]
+```
+
+## Testing
+After deployment, interact with the token using:
+
+```bash
+./scripts/test.sh <profile> <module-address> <recipient-address>
+```
+
+The script registers the recipient to hold the token, mints 1000 tokens, and queries the resulting balance.
+
+### Python
+
+Alternatively, run the Python version (requires the [`aptos-sdk`](https://pypi.org/project/aptos-sdk/) and `PyYAML` packages and a configured Aptos profile):
+
+```bash
+python scripts/test.py <profile> <module-address> <recipient-address>
+```

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <deployer-address> [profile]" >&2
+  exit 1
+fi
+
+ADDR=$1
+PROFILE=${2:-default}
+
+aptos move publish \
+  --package-dir "$(dirname "$0")/.." \
+  --named-addresses token=$ADDR \
+  --profile $PROFILE \
+  --network testnet

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Interact with the deployed token using the Aptos Python SDK.
+
+Usage:
+    python scripts/test.py <profile> <module_address> <recipient_address>
+
+The script expects an Aptos CLI configuration file at ~/.aptos/config.yaml
+from which it loads the private key for the given profile.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+    from aptos_sdk.account import Account
+    from aptos_sdk.client import AptosClient
+    from aptos_sdk.transactions import EntryFunction, TransactionArgument, TransactionPayload
+    from aptos_sdk.account_address import AccountAddress
+except Exception as exc:  # pragma: no cover - import side effect
+    print(f"Missing dependencies: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+TESTNET_NODE = "https://fullnode.testnet.aptoslabs.com/v1"
+
+
+def load_account(profile: str) -> Account:
+    """Load an account from the Aptos CLI config for the given profile."""
+    config = Path.home() / ".aptos" / "config.yaml"
+    data = yaml.safe_load(config.read_text())
+    priv_key = data["profiles"][profile]["private_key"]
+    return Account.load_key(priv_key)
+
+
+def main() -> int:
+    if len(sys.argv) < 4:
+        print("Usage: test.py <profile> <module_address> <recipient_address>", file=sys.stderr)
+        return 1
+    profile, module, recipient = sys.argv[1:4]
+
+    client = AptosClient(TESTNET_NODE)
+    account = load_account(profile)
+    recipient_addr = AccountAddress.from_str(recipient)
+
+    # Register recipient
+    payload: TransactionPayload = EntryFunction.natural(
+        f"{module}::erc20",
+        "register",
+        [],
+        [TransactionArgument(recipient_addr)]
+    )
+    tx_hash = client.submit_transaction(account, payload)
+    client.wait_for_transaction(tx_hash)
+
+    # Mint 1000 tokens
+    payload = EntryFunction.natural(
+        f"{module}::erc20",
+        "mint",
+        [],
+        [TransactionArgument(recipient_addr), TransactionArgument(1000)]
+    )
+    tx_hash = client.submit_transaction(account, payload)
+    client.wait_for_transaction(tx_hash)
+
+    # Query balance
+    result = client.view(
+        f"{module}::erc20::balance",
+        [],
+        [str(recipient_addr)],
+    )
+    print(f"Balance: {result[0]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -lt 3 ]; then
+  echo "Usage: $0 <profile> <module-address> <recipient-address>" >&2
+  exit 1
+fi
+
+PROFILE=$1
+MODULE=$2
+RECIPIENT=$3
+
+# Register recipient to hold the token
+aptos move run \
+  --function-id ${MODULE}::erc20::register \
+  --profile $PROFILE \
+  --network testnet \
+  --args address:$RECIPIENT
+
+# Mint 1000 tokens to recipient
+aptos move run \
+  --function-id ${MODULE}::erc20::mint \
+  --profile $PROFILE \
+  --network testnet \
+  --args address:$RECIPIENT u64:1000
+
+# View recipient balance
+aptos move view \
+  --function-id ${MODULE}::erc20::balance \
+  --network testnet \
+  --args address:$RECIPIENT

--- a/sources/erc20.move
+++ b/sources/erc20.move
@@ -1,0 +1,44 @@
+module token::erc20 {
+    use aptos_framework::managed_coin;
+    use aptos_framework::coin;
+    use std::signer;
+
+    struct Erc20Coin has store, drop, copy {}
+
+    /// Initializes the coin type with metadata.
+    public entry fun initialize(account: &signer) {
+        managed_coin::initialize<Erc20Coin>(
+            account,
+            b"Example ERC20",
+            b"ERC",
+            8,
+            true
+        );
+    }
+
+    /// Registers an account so it can hold the token.
+    public entry fun register(account: &signer) {
+        coin::register<Erc20Coin>(account);
+    }
+
+    /// Mints `amount` tokens to `recipient`.
+    public entry fun mint(owner: &signer, recipient: address, amount: u64) {
+        managed_coin::mint<Erc20Coin>(owner, recipient, amount);
+    }
+
+    /// Burns `amount` tokens from the owner's account.
+    public entry fun burn(owner: &signer, amount: u64) {
+        managed_coin::burn<Erc20Coin>(owner, amount);
+    }
+
+    /// Transfers tokens between users.
+    public entry fun transfer(sender: &signer, recipient: address, amount: u64) {
+        let coin = coin::withdraw<Erc20Coin>(sender, amount);
+        coin::deposit(recipient, coin);
+    }
+
+    /// View function returning the balance of `addr`.
+    public fun balance(addr: address): u64 {
+        coin::balance<Erc20Coin>(addr)
+    }
+}


### PR DESCRIPTION
## Summary
- implement an ERC20-like fungible token in Move
- add deployment and interaction scripts using the Aptos CLI
- document usage and project layout
- add Python-based test script leveraging Aptos SDK

## Testing
- `bash -n scripts/deploy.sh scripts/test.sh`
- `python -m py_compile scripts/test.py`
- `pip install aptos-sdk PyYAML` *(fails: Could not find a version that satisfies the requirement aptos-sdk)*
- `python scripts/test.py default 0x1 0x1` *(fails: Missing dependencies: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68be9040ca8083278745415fe701ea2e